### PR TITLE
Performance optimizations

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -317,9 +317,8 @@ sub _new_from_self {
 sub _handle_offset_modifier {
     my $self = shift;
 
-    $self->{offset_modifier} = 0;
-
     return if $self->{tz}->is_floating;
+    $self->{offset_modifier} = 0;
 
     my $second       = shift;
     my $utc_is_valid = shift;


### PR DESCRIPTION
*   Use a cache for timezones created during this package's lifetime. There's a very finite number of those, and they are constant.

*   Code that manipulates a lot of DateTime objects can skip some expensive validation when creating a lot of DateTimes, by passing `__skip_validation__ => 1` to the constructor.
    
    This is mainly used for DateTimes which are created from other DateTimes (presumed to already be valid).
 * don't set a variable before you even know you're going to need it.
 * Instead of carefully checking if the object we work with has the shape we want it to have, it's usually faster to just plunge ahead and deal with the aftermath later. When you have your typical use case most of the time, performance wins can be noticeable.
    
    Note that `eval` statements here are constructed in such a way that if they fail, they don't produce side effects.
